### PR TITLE
Реализовал MoveCameraTowards

### DIFF
--- a/internal.cpp
+++ b/internal.cpp
@@ -96,6 +96,8 @@ void UpdateGameState(Context &ctx) {
         if (IsKeyPressed(KEY_ENTER) || (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && IsMouseOnButton(startBtnCollider))) {
             ctx.state = GameState::IS_ALIVE;
             ctx.current_scene = ctx.scenes["game"];
+            Object &player = *find_player(ctx.current_scene);
+            ctx.camera_pos = player.position;
             ctx.lives = 3;
             ctx.score = 0;
             ctx.time = 0;

--- a/user.cpp
+++ b/user.cpp
@@ -145,7 +145,13 @@ void MakeJump(Object &obj, float dt) {}
 // Возможное решение может занимать примерно 5 строк.
 // Ваше решение может сильно отличаться.
 //
-void MoveCameraTowards(Context &ctx, Object &obj, float dt) {}
+void MoveCameraTowards(Context &ctx, Object &obj, float dt) {
+    Vector2 dv = obj.position - ctx.camera_pos;
+    if (Vector2Length(dv) < 0.15f) {
+        return ;
+    }
+    ctx.camera_pos += dv * 2 * dt;
+}
 
 // Задание CheckPlayerDeath.
 //


### PR DESCRIPTION
Закрывает #7 

Вычисляется смещение игрока относительно камеры. Итоговое смещение пропорционально разнице времени dt. При этом смещение домножается на 2. Так запоздание камеры меньше, что выглядит приятнее.
Камера движется с запозданием, и теперь изначально смещена к игроку. Это сделано, чтобы камере не нужно было время для смещения к игроку из нулевых координат на первых секундах игры.